### PR TITLE
Add html + js parsing to get store object from script

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,10 +1,22 @@
-const express = require('express');
-const routes = require('./src/routes');
-const app = express();
-const port = process.env.PORT || 80;
+import { ResponseType } from "./src/types/responseTypes";
+import * as stockService from './src/datasources/yahoo';
+import { buildResponse } from "./src/utils/responseBuilder";
 
-routes(app);
+const args = process.argv.slice(2);
 
-app.listen(port, () => {
-    console.log(`Server running at http://localhost:${port}`);
+if(args.length === 0) {
+    const express = require('express');
+    const routes = require('./src/routes');
+    const app = express();
+    const port = process.env.PORT || 80;
+    routes(app);
+    app.listen(port, () => {
+        console.log(`Server running at http://localhost:${port}`);
+    });
+}
+
+
+const results = args.map(ticker => stockService.fetchData(ticker));
+Promise.all(results).then(stocks => {
+    console.log(buildResponse(stocks, ResponseType.text));
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/js-yaml": "^4.0.0",
         "@types/node": "^14.14.28",
         "chai": "^4.3.0",
+        "esbuild": "^0.8.46",
         "mocha": "^8.3.0",
         "nodemon": "^2.0.7",
         "ts-node": "^9.1.1",
@@ -968,6 +969,16 @@
       "dev": true,
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.8.46",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.46.tgz",
+      "integrity": "sha512-xck9sXNCNmjDHCCfxTCyhKTiFuEBweh+IDAhMLOJI990v1Fzii6MyIkT1LbkvjgoVgPX2SK1kpi5eZVGNrl8yg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
       }
     },
     "node_modules/escalade": {
@@ -3698,6 +3709,12 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "esbuild": {
+      "version": "0.8.46",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.46.tgz",
+      "integrity": "sha512-xck9sXNCNmjDHCCfxTCyhKTiFuEBweh+IDAhMLOJI990v1Fzii6MyIkT1LbkvjgoVgPX2SK1kpi5eZVGNrl8yg==",
+      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,16 +5,20 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "stocks",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/express": "^4.17.11",
+        "acorn": "^8.0.5",
         "axios": "^0.21.1",
         "body-parser": "^1.19.0",
         "cli-table3": "^0.6.0",
         "colors": "^1.4.0",
         "express": "^4.17.1",
-        "js-yaml": "^4.0.0"
+        "js-yaml": "^4.0.0",
+        "node-html-parser": "^2.1.0",
+        "recast": "^0.20.4"
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.0",
@@ -144,6 +148,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.5.tgz",
+      "integrity": "sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ansi-align": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
@@ -260,6 +275,17 @@
       "dev": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axios": {
@@ -564,6 +590,7 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -975,6 +1002,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -1278,7 +1317,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
       "bin": {
         "he": "bin/he"
       }
@@ -1746,6 +1784,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-html-parser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-2.1.0.tgz",
+      "integrity": "sha512-kbCNfqjrwHAbG+mevL8aqjwVtF0Qv66XurWHoGLOc5G9rPR1L3k602jfeczAUUBldLNnCrdsDmO5G5nqAoMW+g==",
+      "dependencies": {
+        "he": "1.2.0"
+      }
+    },
     "node_modules/nodemon": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.7.tgz",
@@ -2091,6 +2137,20 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recast": {
+      "version": "0.20.4",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.4.tgz",
+      "integrity": "sha512-6qLIBGGRcwjrTZGIiBpJVC/NeuXpogXNyRQpqU1zWPUigCphvApoCs9KIwDYh1eDuJ6dAFlQoi/QUyE5KQ6RBQ==",
+      "dependencies": {
+        "ast-types": "0.14.2",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/registry-auth-token": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
@@ -2253,7 +2313,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2403,6 +2462,11 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -2972,6 +3036,11 @@
         "negotiator": "0.6.2"
       }
     },
+    "acorn": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.5.tgz",
+      "integrity": "sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg=="
+    },
     "ansi-align": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
@@ -3067,6 +3136,14 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
+    },
+    "ast-types": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+      "requires": {
+        "tslib": "^2.0.1"
+      }
     },
     "axios": {
       "version": "0.21.1",
@@ -3645,6 +3722,11 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true
     },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -3888,8 +3970,7 @@
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "http-cache-semantics": {
       "version": "4.1.0",
@@ -4249,6 +4330,14 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
+    "node-html-parser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-2.1.0.tgz",
+      "integrity": "sha512-kbCNfqjrwHAbG+mevL8aqjwVtF0Qv66XurWHoGLOc5G9rPR1L3k602jfeczAUUBldLNnCrdsDmO5G5nqAoMW+g==",
+      "requires": {
+        "he": "1.2.0"
+      }
+    },
     "nodemon": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.7.tgz",
@@ -4513,6 +4602,17 @@
         "picomatch": "^2.2.1"
       }
     },
+    "recast": {
+      "version": "0.20.4",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.4.tgz",
+      "integrity": "sha512-6qLIBGGRcwjrTZGIiBpJVC/NeuXpogXNyRQpqU1zWPUigCphvApoCs9KIwDYh1eDuJ6dAFlQoi/QUyE5KQ6RBQ==",
+      "requires": {
+        "ast-types": "0.14.2",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tslib": "^2.0.1"
+      }
+    },
     "registry-auth-token": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
@@ -4656,8 +4756,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-support": {
       "version": "0.5.19",
@@ -4764,6 +4863,11 @@
           "dev": true
         }
       }
+    },
+    "tslib": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "type-detect": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.ts",
   "scripts": {
     "watch": "nodemon",
-    "build": "tsc",
+    "build": "esbuild index.ts --bundle --outfile=dist/out.js --platform=node",
     "start": "node ./dist/index.js",
     "start:dev": "node ./dist/index.js",
     "prestart:dev": "npm run build"
@@ -17,6 +17,7 @@
     "@types/js-yaml": "^4.0.0",
     "@types/node": "^14.14.28",
     "chai": "^4.3.0",
+    "esbuild": "^0.8.46",
     "mocha": "^8.3.0",
     "nodemon": "^2.0.7",
     "ts-node": "^9.1.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "watch": "nodemon",
     "build": "tsc",
-    "start": "node ./dist/index.js"
+    "start": "node ./dist/index.js",
+    "prestart": "npm run build"
   },
   "repository": "https://github.com/fsschmitt/stocks",
   "author": "Felipe Schmitt <492108+fsschmitt@users.noreply.github.com>",
@@ -22,11 +23,14 @@
   },
   "dependencies": {
     "@types/express": "^4.17.11",
+    "acorn": "^8.0.5",
     "axios": "^0.21.1",
     "body-parser": "^1.19.0",
     "cli-table3": "^0.6.0",
     "colors": "^1.4.0",
     "express": "^4.17.1",
-    "js-yaml": "^4.0.0"
+    "js-yaml": "^4.0.0",
+    "node-html-parser": "^2.1.0",
+    "recast": "^0.20.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "watch": "nodemon",
     "build": "tsc",
     "start": "node ./dist/index.js",
-    "prestart": "npm run build"
+    "start:dev": "node ./dist/index.js",
+    "prestart:dev": "npm run build"
   },
   "repository": "https://github.com/fsschmitt/stocks",
   "author": "Felipe Schmitt <492108+fsschmitt@users.noreply.github.com>",

--- a/src/datasources/yahoo.ts
+++ b/src/datasources/yahoo.ts
@@ -82,7 +82,7 @@ const getStockInfo = (quoteData: object, ticker: string): Stock => {
     name: parseName(quoteData, "shortName"),
     price: parseValue(quoteData, "regularMarketPrice"),
     change: parseValue(quoteData, "regularMarketChange"),
-    changePercentage: parseValue(quoteData, "regularMarketChangePercent") + "%",
+    changePercentage: parseValue(quoteData, "regularMarketChangePercent").toFixed(2) + "%",
     date: parseDate(quoteData, "regularMarketTime"),
     time: parseTime(quoteData, "regularMarketTime"),
     dayLow: parseValue(quoteData, "regularMarketDayRange").split("-")[0].trim(),

--- a/src/datasources/yahoo.ts
+++ b/src/datasources/yahoo.ts
@@ -71,6 +71,11 @@ const parseDate = (data: object, key: string): string => {
   return new Date(data[key].raw * 1000).toLocaleDateString();
 };
 
+const parseTime = (data: object, key: string): string => {
+  //@ts-ignore
+  return new Date(data[key].raw * 1000).toLocaleTimeString();
+};
+
 const getStockInfo = (quoteData: object, ticker: string): Stock => {
   let stock: Stock = {
     ticker,
@@ -79,7 +84,7 @@ const getStockInfo = (quoteData: object, ticker: string): Stock => {
     change: parseValue(quoteData, "regularMarketChange"),
     changePercentage: parseValue(quoteData, "regularMarketChangePercent") + "%",
     date: parseDate(quoteData, "regularMarketTime"),
-    time: parseValue(quoteData, "regularMarketTime"),
+    time: parseTime(quoteData, "regularMarketTime"),
     dayLow: parseValue(quoteData, "regularMarketDayRange").split("-")[0].trim(),
     dayHigh: parseValue(quoteData, "regularMarketDayRange").split("-")[1]
       .trim(),

--- a/src/datasources/yahoo.ts
+++ b/src/datasources/yahoo.ts
@@ -92,5 +92,9 @@ const getStockInfo = (quoteData: object, ticker: string): Stock => {
     week52High: parseValue(quoteData, "fiftyTwoWeekRange").split("-")[1].trim(),
   };
 
+  stock.toString = function() {
+    return `${this.ticker}: ${this.price} (${this.changePercentage})`
+  }
+
   return stock;
 };

--- a/src/datasources/yahoo.ts
+++ b/src/datasources/yahoo.ts
@@ -69,7 +69,7 @@ const parseName = (data: object, key: string): string => {
 
 const parseDate = (data: object, key: string): string => {
   //@ts-ignore
-  return new Date(data[key].fmt).toLocaleDateString();
+  return new Date(data[key].raw * 1000).toLocaleDateString();
 };
 
 const getStockInfo = (quoteData: object, ticker: string): Stock => {

--- a/src/datasources/yahoo.ts
+++ b/src/datasources/yahoo.ts
@@ -1,50 +1,92 @@
-import axios, { AxiosResponse } from 'axios';
-import { Stock } from '../types/stock';
+import axios, { AxiosResponse } from "axios";
+import { Stock } from "../types/stock";
+import { parse } from "node-html-parser";
+import { Parser } from "acorn";
+import * as Recast from "recast";
+import { writeFile } from "fs/promises";
 
-const yahooUrl = 'https://finance.yahoo.com/quote/';
+const yahooUrl = "https://finance.yahoo.com/quote/";
+
+const getStoreJson = (storeScript: any): any => {
+  const ast = Parser.parse(storeScript.rawText as string, {
+    ecmaVersion: "latest",
+    allowAwaitOutsideFunction: false,
+  });
+  let json;
+  Recast.visit(ast, {
+    visitObjectExpression: async function (node) {
+      if (node.parent.value.left?.property.name === "main") {
+        json = JSON.parse(Recast.print(node.value).code);
+
+        return false;
+      }
+      this.traverse(node);
+    },
+  });
+
+  return json;
+};
 
 export const fetchData = async (ticker: string): Promise<Stock> => {
-    return await axios.get(yahooUrl + ticker).then( (response: AxiosResponse) => {
-        return getStockInfo(response.data, ticker);
-    }).catch( error => {
-        console.error(`An error has occured while fetching data about the ticker ${ticker}:`, error);
-        return {
-            ticker
-        };
-    });
-}
+  return await axios.get(yahooUrl + ticker).then(
+    async (response: AxiosResponse) => {
+      const html = parse(response.data);
 
-const parseValue = (data: string, key: string): any => {
-    return data.split(key)[1].split("fmt\":\"")[1].split("\"")[0];
-}
+      // Find script that contains store
+      const storeScript = [...html.querySelectorAll("script")].find((node) => {
+        if (node.rawText.includes("root.App.main")) {
+          return node;
+        }
+      });
 
-const parseName = (data: string, key: string): string => {
-    return data.split(key)[1].split(":")[1].split(",")[0].replace(/"/g, '');
-}
+      // Parse js to get store value
+      const json = getStoreJson(storeScript);
+      // Get ticker from store
+      const quoteData = json.context.dispatcher.stores.StreamDataStore.quoteData[ticker];
 
-const parseDate = (data: string, key: string): string => {
-    let d = new Date(0);
-    let seconds = Number.parseInt(data.split(key)[1].split(":{\"raw\":\"")[0].split(":{\"raw\":")[1].split("\"")[0].split(',')[0]);
-    d.setUTCSeconds(seconds);
-    return d.toLocaleDateString()
-}
+      return getStockInfo(quoteData, ticker);
+    },
+  ).catch((error) => {
+    console.error(
+      `An error has occured while fetching data about the ticker ${ticker}:`,
+      error,
+    );
+    return {
+      ticker,
+    };
+  });
+};
 
-const getStockInfo = (body: any, ticker: string): Stock => {
-    let stockInfo = body.split(`"${ticker}":{"sourceInterval"`)[1];
+const parseValue = (data: object, key: string): any => {
+  //@ts-ignore
+  return data[key].raw;
+};
 
-    let stock: Stock = {
-        ticker,
-        name: parseName(stockInfo, 'shortName'),
-        price: parseValue(stockInfo, 'regularMarketPrice'),
-        change: parseValue(stockInfo, 'regularMarketChange'),
-        changePercentage: parseValue(stockInfo, 'regularMarketChangePercent'),
-        date: parseDate(stockInfo, 'regularMarketTime'),
-        time: parseValue(stockInfo, 'regularMarketTime'),
-        dayLow: parseValue(stockInfo, 'regularMarketDayRange').split('-')[0].trim(),
-        dayHigh: parseValue(stockInfo, 'regularMarketDayRange').split('-')[1].trim(),
-        week52Low: parseValue(stockInfo, 'fiftyTwoWeekRange').split('-')[0].trim(),
-        week52High: parseValue(stockInfo, 'fiftyTwoWeekRange').split('-')[1].trim(),
-    }
+const parseName = (data: object, key: string): string => {
+  //@ts-ignore
+  return data[key];
+};
 
-    return stock;
-}
+const parseDate = (data: object, key: string): string => {
+  //@ts-ignore
+  return new Date(data[key].fmt).toLocaleDateString();
+};
+
+const getStockInfo = (quoteData: object, ticker: string): Stock => {
+  let stock: Stock = {
+    ticker,
+    name: parseName(quoteData, "shortName"),
+    price: parseValue(quoteData, "regularMarketPrice"),
+    change: parseValue(quoteData, "regularMarketChange"),
+    changePercentage: parseValue(quoteData, "regularMarketChangePercent"),
+    date: parseDate(quoteData, "regularMarketTime"),
+    time: parseValue(quoteData, "regularMarketTime"),
+    dayLow: parseValue(quoteData, "regularMarketDayRange").split("-")[0].trim(),
+    dayHigh: parseValue(quoteData, "regularMarketDayRange").split("-")[1]
+      .trim(),
+    week52Low: parseValue(quoteData, "fiftyTwoWeekRange").split("-")[0].trim(),
+    week52High: parseValue(quoteData, "fiftyTwoWeekRange").split("-")[1].trim(),
+  };
+
+  return stock;
+};

--- a/src/datasources/yahoo.ts
+++ b/src/datasources/yahoo.ts
@@ -27,9 +27,8 @@ const getStoreJson = (storeScript: any): any => {
   return json;
 };
 
-export const fetchData = async (tickers: string[]): Promise<Stock[]> => {
-  const remoteUrl = encodeURI(yahooUrl + tickers.join(","));
-  return await axios.get(remoteUrl).then(
+export const fetchData = async (ticker: string): Promise<Stock> => {
+  return await axios.get(yahooUrl + ticker).then(
     async (response: AxiosResponse) => {
       const html = parse(response.data);
 
@@ -42,23 +41,18 @@ export const fetchData = async (tickers: string[]): Promise<Stock[]> => {
 
       // Parse js to get store value
       const json = getStoreJson(storeScript);
-      const stocks: Stock[] = [];
-      console.log(JSON.stringify(json.context.dispatcher.stores.StreamDataStore.quoteData));
-      tickers.forEach(ticker => {
-        const quoteData = json.context.dispatcher.stores.StreamDataStore.quoteData[ticker];
-        console.log(JSON.stringify(quoteData));
-        stocks.push(getStockInfo(quoteData, ticker));
-      });
+      const quoteData = json.context.dispatcher.stores.StreamDataStore.quoteData[ticker];
       // Get ticker from store
-
-      return stocks;
+      return getStockInfo(quoteData, ticker);
     },
   ).catch((error) => {
     console.error(
-      `An error has occured while fetching data about the tickers ${tickers}:`,
+      `An error has occured while fetching data about the tickers ${ticker}:`,
       error,
     );
-    return [];
+    return {
+      ticker,
+    };
   });
 };
 
@@ -83,7 +77,7 @@ const getStockInfo = (quoteData: object, ticker: string): Stock => {
     name: parseName(quoteData, "shortName"),
     price: parseValue(quoteData, "regularMarketPrice"),
     change: parseValue(quoteData, "regularMarketChange"),
-    changePercentage: parseValue(quoteData, "regularMarketChangePercent"),
+    changePercentage: parseValue(quoteData, "regularMarketChangePercent") + "%",
     date: parseDate(quoteData, "regularMarketTime"),
     time: parseValue(quoteData, "regularMarketTime"),
     dayLow: parseValue(quoteData, "regularMarketDayRange").split("-")[0].trim(),

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -11,7 +11,7 @@ module.exports = (app: any) => {
         const results = tickers.map(ticker => stockService.fetchData(ticker));
         const stocks: Stock[] = await Promise.all(results);
         let response = buildResponse(stocks, responseType);
-        res.send(response);
+        res.send(response + '\n');
     });
 }
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -8,14 +8,7 @@ module.exports = (app: any) => {
     app.get('/:tickers', async (req : Request, res : Response) => {
         const responseType = getResponseType(req);
         const tickers = req.params.tickers.split(',').map((ticker: string) => ticker.trim());
-
-        const stocks: Stock[] = [];
-        for (let i = 0; i < tickers.length; i++) {
-            const ticker = tickers[i];
-            console.info(`Fetching data for ticker: ${ticker}...`);
-            stocks.push(await stockService.fetchData(ticker));
-        }
-
+        const stocks: Stock[] = await stockService.fetchData(tickers);
         let response = buildResponse(stocks, responseType);
         res.send(response);
     });

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -19,13 +19,11 @@ const getResponseType = (req: Request): ResponseType => {
     if (req.query['format'] === "yaml" || req.is('application/yaml')) {
         return ResponseType.yaml;
     }
-    else if (req.query['format'] === "table" || req.is('application/table')) {
-        return ResponseType.table;
-    }
-    else if (req.query['format'] === "text" || req.is('application/text')) {
+    if (req.query['format'] === "text" || req.is('application/text')) {
         return ResponseType.text;
     }
-    else {
+    if (req.query['format'] === "json" || req.is('application/json')) {
         return ResponseType.json;
     }
+    return ResponseType.table;
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -8,7 +8,8 @@ module.exports = (app: any) => {
     app.get('/:tickers', async (req : Request, res : Response) => {
         const responseType = getResponseType(req);
         const tickers = req.params.tickers.split(',').map((ticker: string) => ticker.trim());
-        const stocks: Stock[] = await stockService.fetchData(tickers);
+        const results = tickers.map(ticker => stockService.fetchData(ticker));
+        const stocks: Stock[] = await Promise.all(results);
         let response = buildResponse(stocks, responseType);
         res.send(response);
     });

--- a/src/types/stock.ts
+++ b/src/types/stock.ts
@@ -3,7 +3,7 @@ export interface Stock {
     name?: string,
     price?: number,
     change?: number,
-    changePercentage?: number,
+    changePercentage?: string,
     date?: string,
     time?: string,
     dayLow?: number,

--- a/src/utils/responseBuilder.ts
+++ b/src/utils/responseBuilder.ts
@@ -45,7 +45,7 @@ const buildTable = (responseObj: any) => {
 }
 
 const setColor = (str: string): string => {
-    if (str.includes('%') && !isNaN(Number(str.split('%')[0]))) {
+    if (String(str).includes('%') && !isNaN(Number(str.split('%')[0]))) {
         return (Number(str.split('%')[0]) > 0.0) ? colors.green(str) : colors.red(str);
     }
     return colors.cyan(str);

--- a/src/utils/responseBuilder.ts
+++ b/src/utils/responseBuilder.ts
@@ -3,7 +3,9 @@ import yaml from 'js-yaml';
 import Table from "cli-table3";
 import colors from "colors";
 
-export const buildResponse = (responseObj: any, responseType: ResponseType): any => {
+const unallowedValues = ['function', 'object'];
+
+export const buildResponse = (responseObj: any[], responseType: ResponseType): any => {
     switch (responseType) {
         case ResponseType.json:
             return responseObj;
@@ -12,7 +14,7 @@ export const buildResponse = (responseObj: any, responseType: ResponseType): any
         case ResponseType.table:
             return buildTable(responseObj);
         case ResponseType.text:
-            return `Response: ${JSON.stringify(responseObj)}`;
+            return responseObj.join(' ');
         default:
             return responseObj;
     }
@@ -20,7 +22,7 @@ export const buildResponse = (responseObj: any, responseType: ResponseType): any
 
 const buildHeader = (row: any): string[] => {
     let head: string[] = [];
-    Object.keys(row).forEach(key => {
+    Object.keys(row).filter(key => !unallowedValues.includes(typeof row[key])).forEach(key => {
         var tmp = key.replace( /([A-Z])/g, " $1" );
         var headerName = tmp.charAt(0).toUpperCase() + tmp.slice(1);
         head.push(colors.dim(headerName));
@@ -39,7 +41,7 @@ const buildTable = (responseObj: any) => {
     });
     responseArr.forEach(obj => {
         let values: string[] = Object.values(obj);
-        table.push(values.map(v => setColor(v)));
+        table.push(values.filter(v => !unallowedValues.includes(typeof v)).map(v => setColor(v)));
     });
     return table.toString();
 }


### PR DESCRIPTION
- Adds a way to parse html, get the specific script element, and use ast to parse JS and get store object.
- Use store object to return API values
- Adds "prestart:dev" and "dev" script to build before starting
- Generates a `dist/out.js` bundle which is directly executable with `node dist/out.js`